### PR TITLE
Fix NullPointerException

### DIFF
--- a/src/main/java/com/gibraltar/strait/feature/FrameFeature.java
+++ b/src/main/java/com/gibraltar/strait/feature/FrameFeature.java
@@ -62,6 +62,12 @@ public class FrameFeature extends Feature
     public void onRightClickBlock(PlayerInteractEvent.RightClickBlock event)
     {
         ItemStack itemstack = event.getItemStack();
+        
+        if (itemstack == null)
+        {
+            return;
+        }
+	
         EnumFacing facing = event.getFace();
         BlockPos blockpos = event.getPos().offset(facing);
         World world = event.getWorld();


### PR DESCRIPTION
Occurs when a player right clicks a block with an empty hand. This will probably also have to be fixed in 1.9.